### PR TITLE
Automation of Linux and Windows' Tauri builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,4 +73,4 @@ jobs:
           projectPath: ./lonewolf-tauri
           tagName: lonewolf-v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version
           releaseName: "Lonewolf v__VERSION__"
-          releaseBody: "Check the assets below :D"
+          releaseBody: "This build was automatically created. Check the assets below for the binaries for your platform :D"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,12 +60,6 @@ jobs:
           make test-unit
           cd ..
 
-      # - name: build executable
-      #   run: |
-      #     cd lonewolf-tauri
-      #     make build
-      #     cd ..
-
       - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,7 +64,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          projectPath: ./lonewolf-tauri
+          projectPath: ./lonewolf-tauri/src-tauri
           tagName: lonewolf-v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version
           releaseName: "Lonewolf v__VERSION__"
           releaseBody: "This build was automatically created. Check the assets below for the binaries for your platform :D"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,12 +65,36 @@ jobs:
           make build
           cd ..
 
-      - uses: tauri-apps/tauri-action@v0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # - uses: tauri-apps/tauri-action@v0
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     tagName: app-v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version
+      #     releaseName: "App v__VERSION__"
+      #     releaseBody: "See the assets to download this version and install."
+      #     releaseDraft: true
+      #     prerelease: false
+
+      - uses: actions/upload-artifact@v3
+        if: matrix.platform == 'windows-latest'
         with:
-          tagName: app-v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version
-          releaseName: "App v__VERSION__"
-          releaseBody: "See the assets to download this version and install."
-          releaseDraft: true
-          prerelease: false
+          name: Windows MSI Installer
+          path: lonewolf-tauri/src-tauri/target/release/msi
+
+      - uses: actions/upload-artifact@v3
+        if: matrix.platform == 'windows-latest'
+        with:
+          name: Windows NSIS Installer
+          path: lonewolf-tauri/src-tauri/target/release/nsis
+
+      - uses: actions/upload-artifact@v3
+        if: matrix.platform == 'windows-latest'
+        with:
+          name: Windows Standalone Executable
+          path: lonewolf-tauri/src-tauri/target/release/lonewolf.exe
+
+      - uses: actions/upload-artifact@v3
+        if: matrix.platform == 'ubuntu-20.04'
+        with:
+          name: Debian Packages
+          path: lonewolf-tauri/src-tauri/target/release/bundle/deb

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,9 @@
 name: "publish"
 
 on:
-  release:
-    types: [published]
+  push:
+    branches:
+      - main
 
 jobs:
   publish-tauri:
@@ -59,42 +60,17 @@ jobs:
           make test-unit
           cd ..
 
-      - name: build executable
-        run: |
-          cd lonewolf-tauri
-          make build
-          cd ..
+      # - name: build executable
+      #   run: |
+      #     cd lonewolf-tauri
+      #     make build
+      #     cd ..
 
-      # - uses: tauri-apps/tauri-action@v0
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     tagName: app-v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version
-      #     releaseName: "App v__VERSION__"
-      #     releaseBody: "See the assets to download this version and install."
-      #     releaseDraft: true
-      #     prerelease: false
-
-      - uses: actions/upload-artifact@v3
-        if: matrix.platform == 'windows-latest'
+      - uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          name: Windows MSI Installer
-          path: lonewolf-tauri/src-tauri/target/release/msi
-
-      - uses: actions/upload-artifact@v3
-        if: matrix.platform == 'windows-latest'
-        with:
-          name: Windows NSIS Installer
-          path: lonewolf-tauri/src-tauri/target/release/nsis
-
-      - uses: actions/upload-artifact@v3
-        if: matrix.platform == 'windows-latest'
-        with:
-          name: Windows Standalone Executable
-          path: lonewolf-tauri/src-tauri/target/release/lonewolf.exe
-
-      - uses: actions/upload-artifact@v3
-        if: matrix.platform == 'ubuntu-20.04'
-        with:
-          name: Debian Packages
-          path: lonewolf-tauri/src-tauri/target/release/bundle/deb
+          projectPath: ./lonewolf-tauri
+          tagName: lonewolf-v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version
+          releaseName: "Lonewolf v__VERSION__"
+          releaseBody: "Check the assets below :D"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,76 @@
+name: "publish"
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-tauri:
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ubuntu-20.04, windows-latest]
+
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: install dependencies (ubuntu only)
+        if: matrix.platform == 'ubuntu-20.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf
+
+      - name: change Makefile (windows only)
+        if: matrix.platform == 'windows-latest'
+        run: |
+          cd lonewolf-tauri
+          mv Makefile Makefile.lin
+          mv Makefile.win Makefile
+          cd ..
+
+      - name: install frontend dependencies
+        run: |
+          cd lonewolf-tauri
+          make npm-install
+          cd ..
+
+      - name: compile assets
+        run: |
+          cd lonewolf-tauri
+          make icons
+          make tauri-icons
+          cd ..
+      
+      - name: check and test
+        run: |
+          cd lonewolf-tauri
+          make check
+          make test-unit
+          cd ..
+
+      - name: build executable
+        run: |
+          cd lonewolf-tauri
+          make build
+          cd ..
+
+      - uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tagName: app-v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version
+          releaseName: "App v__VERSION__"
+          releaseBody: "See the assets to download this version and install."
+          releaseDraft: true
+          prerelease: false

--- a/Development.md
+++ b/Development.md
@@ -9,8 +9,8 @@ There are a few places where version numbers appare:
 |Core   |lonewolf/content/version.ts:3                   |`x.y.z`|Yes |
 |Web    |lonewolf-web/src-platform/content/version.ts:3  |`x.y.z`|Yes |
 |Desktop|lonewolf-tauri/src-platform/content/version.ts:3|`x.y.z`|Yes |
+|Desktop|lonewolf-tauri/src-tauri/tauri.conf.json:11     |`x.y.z`|Yes |
 |Desktop|lonewolf-tauri/src-tauri/Cargo.toml:3           |`0.0.0`|No  |
-|Desktop|lonewolf-tauri/src-tauri/tauri.conf.json:11     |`0.0.0`|No  |
 |Desktop|lonewolf-tauri/package.json:4                   |`0.0.0`|No  |
 |Desktop|lonewolf-tauri/package-lock.json:3              |`0.0.0`|No  |
 |Desktop|lonewolf-tauri/package-lock.json:9              |`0.0.0`|No  |

--- a/lonewolf-tauri/Makefile
+++ b/lonewolf-tauri/Makefile
@@ -38,11 +38,11 @@ type-check-tauri:
 
 src-tauri/icons/512x512-lonewolf.png: src/assets/icon.svg
 	mkdir -p src-tauri/icons
-	rsvg-convert -b "#ffffff00" src/assets/icon.svg --width 512 --height 512 --output src-tauri/icons/512x512-lonewolf.png
+	node bin/svg2png.mjs -b "#ffffff00" src/assets/icon.svg --width 512 --height 512 --output src-tauri/icons/512x512-lonewolf.png
 
 public/lonewolf.png: src/assets/icon.svg
-	rsvg-convert -b "#ffffff00" src/assets/lonewolf.svg --width 512 --height 512 --output public/lonewolf.png
+	node bin/svg2png.mjs -b "#ffffff00" src/assets/lonewolf.svg --width 512 --height 512 --output public/lonewolf.png
 
 public/icon.png: src/assets/icon.svg
-	rsvg-convert -b "#ffffff00" src/assets/icon.svg --width 128 --height 128 --output public/icon.png
+	node bin/svg2png.mjs -b "#ffffff00" src/assets/icon.svg --width 128 --height 128 --output public/icon.png
 

--- a/lonewolf-tauri/Makefile
+++ b/lonewolf-tauri/Makefile
@@ -22,6 +22,7 @@ lint:
 
 npm-install:
 	npm install
+	npm install --no-save sharp
 
 tauri-icons: src-tauri/icons/512x512-lonewolf.png
 	npm run tauri icon -- src-tauri/icons/512x512-lonewolf.png -o src-tauri/icons

--- a/lonewolf-tauri/package-lock.json
+++ b/lonewolf-tauri/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lonewolf",
-  "version": "0.0.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lonewolf",
-      "version": "0.0.0",
+      "version": "1.1.1",
       "dependencies": {
         "@babel/types": "^7.22.3",
         "@codemirror/autocomplete": "^6.2.0",

--- a/lonewolf-tauri/package.json
+++ b/lonewolf-tauri/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lonewolf",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/lonewolf-tauri/src-tauri/Cargo.lock
+++ b/lonewolf-tauri/src-tauri/Cargo.lock
@@ -2798,7 +2798,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-store"
-version = "1.1.1"
+version = "0.0.0"
 source = "git+https://github.com/tauri-apps/plugins-workspace?branch=v1#5b814f56e6368fdec46c4ddb04a07e0923ff995a"
 dependencies = [
  "log",

--- a/lonewolf-tauri/src-tauri/Cargo.lock
+++ b/lonewolf-tauri/src-tauri/Cargo.lock
@@ -1481,7 +1481,7 @@ dependencies = [
 
 [[package]]
 name = "lonewolf"
-version = "0.0.0"
+version = "1.1.1"
 dependencies = [
  "faccess",
  "infer 0.13.0",
@@ -2798,7 +2798,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-store"
-version = "0.0.0"
+version = "1.1.1"
 source = "git+https://github.com/tauri-apps/plugins-workspace?branch=v1#5b814f56e6368fdec46c4ddb04a07e0923ff995a"
 dependencies = [
  "log",

--- a/lonewolf-tauri/src-tauri/Cargo.toml
+++ b/lonewolf-tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lonewolf"
-version = "1.1.3"
+version = "0.0.0"
 description = "Organize and track your tasks with ease and flexibility. Lonewolf is a productivity application based on the principles of Kanban. Write rich text in markdown format, labels your tasks with tags, add check lists, set due dates, attach files and more."
 authors = ["Mario Aichinger <aichingm@gmail.com>"]
 license = ""

--- a/lonewolf-tauri/src-tauri/Cargo.toml
+++ b/lonewolf-tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lonewolf"
-version = "1.1.1"
+version = "1.1.3"
 description = "Organize and track your tasks with ease and flexibility. Lonewolf is a productivity application based on the principles of Kanban. Write rich text in markdown format, labels your tasks with tags, add check lists, set due dates, attach files and more."
 authors = ["Mario Aichinger <aichingm@gmail.com>"]
 license = ""

--- a/lonewolf-tauri/src-tauri/Cargo.toml
+++ b/lonewolf-tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lonewolf"
-version = "0.0.0"
+version = "1.1.1"
 description = "Organize and track your tasks with ease and flexibility. Lonewolf is a productivity application based on the principles of Kanban. Write rich text in markdown format, labels your tasks with tags, add check lists, set due dates, attach files and more."
 authors = ["Mario Aichinger <aichingm@gmail.com>"]
 license = ""

--- a/lonewolf-tauri/src-tauri/tauri.conf.json
+++ b/lonewolf-tauri/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "lonewolf",
-    "version": "1.1.2"
+    "version": "1.1.1"
   },
   "tauri": {
     "cli": {

--- a/lonewolf-tauri/src-tauri/tauri.conf.json
+++ b/lonewolf-tauri/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "lonewolf",
-    "version": "0.0.0"
+    "version": "1.1.1"
   },
   "tauri": {
     "cli": {
@@ -44,7 +44,11 @@
         "all": false,
         "readFile": true,
         "writeFile": true,
-        "scope": ["$HOME", "$HOME/*", "$HOME/**"]
+        "scope": [
+          "$HOME",
+          "$HOME/*",
+          "$HOME/**"
+        ]
       }
     },
     "bundle": {

--- a/lonewolf-tauri/src-tauri/tauri.conf.json
+++ b/lonewolf-tauri/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "lonewolf",
-    "version": "1.1.1"
+    "version": "1.1.2"
   },
   "tauri": {
     "cli": {

--- a/lonewolf-web/package-lock.json
+++ b/lonewolf-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lonewolf",
-  "version": "1.1.1",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lonewolf",
-      "version": "1.1.1",
+      "version": "0.0.0",
       "dependencies": {
         "@codemirror/autocomplete": "^6.2.0",
         "@codemirror/lang-javascript": "^6.0.2",

--- a/lonewolf-web/package-lock.json
+++ b/lonewolf-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lonewolf",
-  "version": "0.0.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lonewolf",
-      "version": "0.0.0",
+      "version": "1.1.1",
       "dependencies": {
         "@codemirror/autocomplete": "^6.2.0",
         "@codemirror/lang-javascript": "^6.0.2",

--- a/lonewolf-web/package.json
+++ b/lonewolf-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lonewolf",
-  "version": "1.1.1",
+  "version": "0.0.0",
   "scripts": {
     "dev": "vite",
     "build": "run-p type-check build-only",

--- a/lonewolf-web/package.json
+++ b/lonewolf-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lonewolf",
-  "version": "0.0.0",
+  "version": "1.1.1",
   "scripts": {
     "dev": "vite",
     "build": "run-p type-check build-only",

--- a/lonewolf/content/contributors.ts
+++ b/lonewolf/content/contributors.ts
@@ -12,6 +12,12 @@ const content: Contributor[] = [
         years: "2023 - *",
         description: "Created the project and maintains it!"
     },
+    {
+        name: "Félix Fischer",
+        contact: "felix91gr@gmail.com",
+        years: "2023",
+        description: "Helped automate builds and pestered Mario to figure out Windows compatibility together"
+    },
 ]
 
 export default content


### PR DESCRIPTION
Heeey. I hope these can be squashed together or something, because I needed to push a ton of commits in order to test the GA system.

Added:
- Github Actions' automation for both Linux and Windows
- `rsvg-convert` is no longer required, I believe. At least not for the Tauri build
- Added me as a contributor (I think)
- Point release bump (1.1.1 now)
- Documented a new space where the version number matters (`lonewolf-tauri/src-tauri/tauri.conf.json:11`)

To do before merging: (I'm opening this RN so that you can take a look and give feedback in the meantime)
- Add the `make` command change you mentioned here https://github.com/aichingm/lonewolf/issues/6#issuecomment-1844851441
- Clarify the best way to trigger the GA build. Currently, it triggers a build as soon as any change is pushed to the `main` branch. If the version number present at the `tauri.conf.json` file already has build artifacts in the site, they are overwritten by the GA whenever it runs successfully.